### PR TITLE
Make location names consistent with multiworld

### DIFF
--- a/resources/data/Randomizer/locations_items.json
+++ b/resources/data/Randomizer/locations_items.json
@@ -528,13 +528,13 @@
 	},
 	{
 		"Id": "RESCUED_CHERUB_15",
-		"Name": "Top of elevator Child of Moonlight",
+		"Name": "Elevator top Child of Moonlight",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S20"
 	},
 	{
 		"Id": "Lady[D01Z05S22]",
-		"Name": "Lady of the Six Sorrows, from MD",
+		"Name": "Lady of Sorrows, from MD",
 		"Hint": "The Lady of Sorrows holds *",
 		"Room": "D01Z05S22"
 	},
@@ -568,7 +568,7 @@
 	},
 	{
 		"Id": "Lady[D01Z05S26]",
-		"Name": "Lady of the Six Sorrows, elevator shaft",
+		"Name": "Lady of Sorrows, elevator shaft",
 		"Hint": "The Lady of Sorrows holds *",
 		"Room": "D01Z05S26"
 	},
@@ -1511,7 +1511,7 @@
 	},
 	{
 		"Id": "RESCUED_CHERUB_36",
-		"Name": "Upper west shaft Child of Moonlight",
+		"Name": "Upper west Child of Moonlight",
 		"Hint": "* resides in the Rooftops",
 		"Room": "D06Z01S12",
 		"Logic": "D06Z01S12[W] || D06Z01S12[E] || D06Z01S12[NW] || D06Z01S12[NE] || D06Z01S12[NE2] || wallClimb && (doubleJump || taranto)"
@@ -1735,7 +1735,7 @@
 	},
 	{
 		"Id": "RESCUED_CHERUB_06",
-		"Name": "Starting room Child of Moonlight",
+		"Name": "Start room Child of Moonlight",
 		"Hint": "* resides in the Brotherhood",
 		"Room": "D17Z01S01",
 		"logic": "D17Z01S01[Cherubs1] || taranto || (canClimbOnRoot || canCrossGap9) && (blood || doubleJump || debla || verdiales || tirana || ruby)"

--- a/resources/data/Randomizer/locations_items.json
+++ b/resources/data/Randomizer/locations_items.json
@@ -1,39 +1,39 @@
 [
 	{
 		"Id": "PR14",
-		"Name": "Mud ledge lower",
+		"Name": "Hanging skeleton",
 		"Hint": "* resides in the Holy Line",
 		"Room": "D01Z01S02"
 	},
 	{
 		"Id": "RB07",
-		"Name": "Mud ledge upper",
+		"Name": "Across blood platforms",
 		"Hint": "* resides in the Holy Line",
 		"Room": "D01Z01S02",
 		"Logic": "blood || doubleJump"
 	},
 	{
 		"Id": "CO04",
-		"Name": "Cave ledge",
+		"Name": "Underground ledge",
 		"Hint": "* resides in the Holy Line",
 		"Room": "D01Z01S03"
 	},
 	{
 		"Id": "QI55",
-		"Name": "Cave chest",
+		"Name": "Underground chest",
 		"Hint": "* resides in the Holy Line",
 		"Room": "D01Z01S03",
 		"Logic": "blood && dash && canWaterJump"
 	},
 	{
 		"Id": "RESCUED_CHERUB_07",
-		"Name": "Mud cherub",
+		"Name": "Child of Moonlight",
 		"Hint": "* resides in the Holy Line",
 		"Room": "D01Z01S03"
 	},
 	{
 		"Id": "QI31",
-		"Name": "Deogracias gift",
+		"Name": "Deogracias' gift",
 		"Hint": "Deogracias holds *",
 		"Type": 2,
 		"OriginalItem": "TH",
@@ -42,41 +42,41 @@
 	
 	{
 		"Id": "RE02",
-		"Name": "Bless hand",
+		"Name": "Bless Severed Hand",
 		"Hint": "* requires a blessing",
 		"Room": "D01Z02S01",
 		"Logic": "hand"
 	},
 	{
 		"Id": "RE04",
-		"Name": "Bless cloth",
+		"Name": "Bless Linen Cloth",
 		"Hint": "* requires a blessing",
 		"Room": "D01Z02S01",
 		"Logic": "cloth"
 	},
 	{
 		"Id": "RE10",
-		"Name": "Bless egg",
+		"Name": "Bless Hatched Egg",
 		"Hint": "* requires a blessing",
 		"Room": "D01Z02S01",
 		"Logic": "hatchedEgg"
 	},
 	{
 		"Id": "RB01",
-		"Name": "Sick house",
+		"Name": "Tirso's house, top floor",
 		"Hint": "* resides in Albero",
 		"Room": "D01Z02S02"
 	},
 	{
 		"Id": "QI66",
-		"Name": "Tirso reward 1",
+		"Name": "Tirso's 1st reward",
 		"Hint": "Tirso holds *",
 		"Room": "D01Z02S02",
 		"Logic": "herbs >= 1"
 	},
 	{
 		"Id": "Tirso[500]",
-		"Name": "Tirso reward 2",
+		"Name": "Tirso's 2nd reward",
 		"Hint": "Tirso holds *",
 		"OriginalItem": "Tears[500]",
 		"Room": "D01Z02S02",
@@ -84,7 +84,7 @@
 	},
 	{
 		"Id": "Tirso[1000]",
-		"Name": "Tirso reward 3",
+		"Name": "Tirso's 3rd reward",
 		"Hint": "Tirso holds *",
 		"OriginalItem": "Tears[1000]",
 		"Room": "D01Z02S02",
@@ -92,7 +92,7 @@
 	},
 	{
 		"Id": "Tirso[2000]",
-		"Name": "Tirso reward 4",
+		"Name": "Tirso's 4th reward",
 		"Hint": "Tirso holds *",
 		"OriginalItem": "Tears[2000]",
 		"Room": "D01Z02S02",
@@ -100,7 +100,7 @@
 	},
 	{
 		"Id": "Tirso[5000]",
-		"Name": "Tirso reward 5",
+		"Name": "Tirso's 5th reward",
 		"Hint": "Tirso holds *",
 		"OriginalItem": "Tears[5000]",
 		"Room": "D01Z02S02",
@@ -108,7 +108,7 @@
 	},
 	{
 		"Id": "Tirso[10000]",
-		"Name": "Tirso reward 6",
+		"Name": "Tirso's 6th reward",
 		"Hint": "Tirso holds *",
 		"OriginalItem": "Tears[10000]",
 		"Room": "D01Z02S02",
@@ -116,21 +116,21 @@
 	},
 	{
 		"Id": "QI56",
-		"Name": "Tirso final reward",
+		"Name": "Tirso's final reward",
 		"Hint": "Tirso holds *",
 		"Room": "D01Z02S02",
 		"Logic": "herbs >= 6 && canBeatMercyBoss && canBeatConventBoss && canBeatGrievanceBoss && canBeatMothersBoss && canBeatCanvasesBoss && canBeatPrisonBoss"
 	},
 	{
 		"Id": "RESCUED_CHERUB_08",
-		"Name": "Elevator cherub",
+		"Name": "Child of Moonlight",
 		"Hint": "* resides in Albero",
 		"Room": "D01Z02S03",
 		"Logic": "rodeGotPElevator || pillar || cante || doubleJump || D01Z02S03[NW] && (canCrossGap2 || lorquiana || aubade || cantina || chargeBeam || rangedAttack)"
 	},
 	{
 		"Id": "Lvdovico[500]",
-		"Name": "Tentudia reward 1",
+		"Name": "Lvdovico's 1st reward",
 		"Hint": "Lvdovico holds *",
 		"OriginalItem": "Tears[500]",
 		"Room": "D01Z02S03",
@@ -138,7 +138,7 @@
 	},
 	{
 		"Id": "Lvdovico[1000]",
-		"Name": "Tentudia reward 2",
+		"Name": "Lvdovico's 2nd reward",
 		"Hint": "Lvdovico holds *",
 		"OriginalItem": "Tears[1000]",
 		"Room": "D01Z02S03",
@@ -146,21 +146,21 @@
 	},
 	{
 		"Id": "PR03",
-		"Name": "Tentudia reward 3",
+		"Name": "Lvdovico's 3rd reward",
 		"Hint": "Lvdovico holds *",
 		"Room": "D01Z02S03",
 		"Logic": "tentudiaRemains >= 3"
 	},
 	{
 		"Id": "QI01",
-		"Name": "Cleofas initial gift",
+		"Name": "First gift for Cleofas",
 		"Hint": "Lvdovico holds *",
 		"Room": "D01Z02S03",
 		"Logic": "D04Z02S10[W]"
 	},
 	{
 		"Id": "CO43",
-		"Name": "Outside ossuary",
+		"Name": "Outside Ossuary",
 		"Hint": "* resides in Albero",
 		"Room": "D01Z02S04"
 	},
@@ -172,26 +172,26 @@
 	},
 	{
 		"Id": "Sword[D01Z02S06]",
-		"Name": "Mea Culpa shrine",
-		"Hint": "A Mea Culpa Shrine holds *",
+		"Name": "Mea Culpa altar",
+		"Hint": "A Mea Culpa altar holds *",
 		"Room": "D01Z02S06"
 	},
 	{
 		"Id": "QI65",
-		"Name": "Warp room",
+		"Name": "Gate of Travel room",
 		"Hint": "* resides in Albero",
 		"Room": "D01Z02S07"
 	},
 	{
 		"Id": "RB104",
-		"Name": "Church donation (5000)",
+		"Name": "Donate 5000 Tears",
 		"Hint": "* requires a donation",
 		"LocationFlag": "LOCATION_RB104~D01Z02",
 		"Room": "D01BZ04S01"
 	},
 	{
 		"Id": "RB105",
-		"Name": "Church donation (50000)",
+		"Name": "Donate 50000 Tears",
 		"Hint": "* requires a donation",
 		"Type": 8,
 		"LocationFlag": "LOCATION_RB105~D01Z02",
@@ -199,7 +199,7 @@
 	},
 	{
 		"Id": "PR11",
-		"Name": "Cleofas final gift",
+		"Name": "Final gift for Cleofas",
 		"Hint": "Cleofas holds *",
 		"LocationFlag": "LOCATION_PR11~D01Z02",
 		"Room": "D01BZ04S01",
@@ -296,7 +296,7 @@
 	},
 	{
 		"Id": "QI201",
-		"Name": "Isidora reward",
+		"Name": "Isidora, Voice of the Dead",
 		"Hint": "* is guarded by Isidora",
 		"LocationFlag": "LOCATION_QI201~D01Z02",
 		"Room": "D01BZ08S01",
@@ -305,53 +305,53 @@
 	
 	{
 		"Id": "RB04",
-		"Name": "Lower tree path",
+		"Name": "Lower log path",
 		"Hint": "* resides in the Wastelands",
 		"Room": "D01Z03S01",
 		"Logic": "D01Z03S01[SE]"
 	},
 	{
 		"Id": "CO14",
-		"Name": "Building slide",
+		"Name": "Hidden alcove",
 		"Hint": "* resides in the Wastelands",
 		"Room": "D01Z03S02",
 		"Logic": "dash"
 	},
 	{
 		"Id": "CO36",
-		"Name": "Exterior ledge",
+		"Name": "Outside ledge",
 		"Hint": "* resides in the Wastelands",
 		"Room": "D01Z03S03"
 	},
 	{
 		"Id": "RESCUED_CHERUB_10",
-		"Name": "Exterior cherub",
+		"Name": "Outside Child of Moonlight",
 		"Hint": "* resides in the Wastelands",
 		"Room": "D01Z03S03"
 	},
 	{
 		"Id": "QI06",
-		"Name": "Underneath MD bridge",
+		"Name": "Under broken bridge",
 		"Hint": "* resides in the Wastelands",
 		"Room": "D01Z03S05",
 		"Logic": "blood || boots || canCrossGap3"
 	},
 	{
 		"Id": "RB20",
-		"Name": "Redento meeting 3",
+		"Name": "3rd meeting with Redento",
 		"Hint": "Redento holds *",
 		"Room": "D01Z03S06",
 		"Logic": "redentoRooms >= 3"
 	},
 	{
 		"Id": "HE02",
-		"Name": "Cliffside ledge",
+		"Name": "Cliffside statue",
 		"Hint": "* resides in the Wastelands",
 		"Room": "D01Z03S07"
 	},
 	{
 		"Id": "RESCUED_CHERUB_38",
-		"Name": "Cliffside cherub",
+		"Name": "Cliffside Child of Moonlight",
 		"Hint": "* resides in the Wastelands",
 		"Room": "D01Z03S07",
 		"Logic": "canCrossGap2 || lorquiana || cante || aubade || cantina || ruby || chargeBeam || rangedAttack || preciseSkipsAllowed"
@@ -359,91 +359,91 @@
 	
 	{
 		"Id": "CO30",
-		"Name": "First section hidden wall",
+		"Name": "First area hidden wall",
 		"Hint": "* resides in Mercy",
 		"Room": "D01Z04S05"
 	},
 	{
 		"Id": "CO03",
-		"Name": "Second section ledge",
+		"Name": "Second area ledge",
 		"Hint": "* resides in Mercy",
 		"Room": "D01Z04S06"
 	},
 	{
 		"Id": "RESCUED_CHERUB_09",
-		"Name": "Second section cherub",
+		"Name": "Second area Child of Moonlight",
 		"Hint": "* resides in Mercy",
 		"Room": "D01Z04S06"
 	},
 	{
 		"Id": "PR01",
-		"Name": "Second section ghost ambush",
+		"Name": "Second area trapped chest",
 		"Hint": "* resides in Mercy",
 		"Room": "D01Z04S07"
 	},
 	{
 		"Id": "RB17",
-		"Name": "Red candle",
+		"Name": "First red candle",
 		"Hint": "A candle holds *",
 		"Room": "D01Z04S08"
 	},
 	{
 		"Id": "QI48",
-		"Name": "Hidden battle arena",
+		"Name": "Third area hidden room",
 		"Hint": "* resides in Mercy",
 		"Room": "D01Z04S11"
 	},
 	{
 		"Id": "CO21",
-		"Name": "TSC entrance ledge",
+		"Name": "Behind gate to TSC",
 		"Hint": "* resides in Mercy",
 		"Room": "D01Z04S13",
 		"Logic": "D01Z04S13[SE] || canDiveLaser && (canAirStall || wheel || doubleJump || canEnemyBounce)"
 	},
 	{
 		"Id": "CO38",
-		"Name": "Lower slide room",
+		"Name": "Sliding challenge",
 		"Hint": "* resides in Mercy",
 		"Room": "D01Z04S14",
 		"Logic": "dash"
 	},
 	{
 		"Id": "RESCUED_CHERUB_33",
-		"Name": "TSC entrance cherub",
+		"Name": "Cave Child of Moonlight",
 		"Hint": "* resides in Mercy",
 		"Room": "D01Z04S16",
 		"Logic": "doubleJump || pillar || cante || tirana"
 	},
 	{
 		"Id": "BS01",
-		"Name": "Defeat Ten Piedad",
+		"Name": "Ten Piedad",
 		"Hint": "* is guarded by Ten Piedad",
 		"Room": "D01Z04S18",
 		"Logic": "canBeatMercyBoss"
 	},
 	{
 		"Id": "QI38",
-		"Name": "Holy Visage gift",
+		"Name": "Visage of Attrition",
 		"Hint": "A Holy Visage holds *",
 		"Room": "D01Z04S19"
 	},
 	{
 		"Id": "QI58",
-		"Name": "Shop left",
+		"Name": "Shop item 1",
 		"Hint": "* can be purchased",
 		"LocationFlag": "LOCATION_QI58~D01Z04",
 		"Room": "D01BZ02S01"
 	},
 	{
 		"Id": "RB05",
-		"Name": "Shop middle",
+		"Name": "Shop item 2",
 		"Hint": "* can be purchased",
 		"LocationFlag": "LOCATION_RB05~D01Z04",
 		"Room": "D01BZ02S01"
 	},
 	{
 		"Id": "RB09",
-		"Name": "Shop right",
+		"Name": "Shop item 3",
 		"Hint": "* can be purchased",
 		"LocationFlag": "LOCATION_RB09~D01Z04",
 		"Room": "D01BZ02S01"
@@ -451,90 +451,90 @@
 	
 	{
 		"Id": "CO09",
-		"Name": "WotBC upper entrance",
+		"Name": "Shortcut to WotBC",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S05"
 	},
 	{
 		"Id": "QI67",
-		"Name": "Hidden hand room",
+		"Name": "Hidden alcove near fountain",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S05",
 		"Logic": "dash && canWaterJump"
 	},
 	{
 		"Id": "PR16",
-		"Name": "Eastern upper tunnel chest",
+		"Name": "Upper east tunnel chest",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S06",
 		"Logic": "D01Z05S06[Cherubs] || canWaterJump"
 	},
 	{
 		"Id": "RESCUED_CHERUB_13",
-		"Name": "Eastern upper tunnel cherub",
+		"Name": "Upper east Child of Moonlight",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S06",
 		"Logic": "D01Z05S06[Cherubs] || canWaterJump || pillar || cante || aubade || tirana || canAirStall"
 	},
 	{
 		"Id": "Oil[D01Z05S07]",
-		"Name": "Oil room",
+		"Name": "Oil of the Pilgrims",
 		"Hint": "An oil fountain holds *",
 		"Room": "D01Z05S07"
 	},
 	{
 		"Id": "QI12",
-		"Name": "Veil room ledge",
+		"Name": "Behind gate in miasma room",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S08"
 	},
 	{
 		"Id": "RESCUED_CHERUB_14",
-		"Name": "Veil room cherub",
+		"Name": "Child of Moonlight, miasma room",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S08"
 	},
 	{
 		"Id": "QI45",
-		"Name": "Eastern lower tunnel chest",
+		"Name": "Lower east tunnel chest",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S11"
 	},
 	{
 		"Id": "RESCUED_CHERUB_12",
-		"Name": "Lung tunnel cherub",
+		"Name": "Child of Moonlight, behind pillar",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S13",
 		"Logic": "D01Z05S13[SW] || D01Z05S13[E] && canSurvivePoison3 && canWaterJump"
 	},
 	{
 		"Id": "RESCUED_CHERUB_11",
-		"Name": "Southern water room cherub",
+		"Name": "Child of Moonlight, above water",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S14"
 	},
 	{
 		"Id": "CO41",
-		"Name": "MD lower entrance",
+		"Name": "Behind sewage drips",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S15"
 	},
 	{
 		"Id": "CO32",
-		"Name": "Water ledge near elevator",
+		"Name": "High ledge near elevator shaft",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S17",
 		"Logic": "D01Z05S17[E] || canWaterJump || canCrossGap5"
 	},
 	{
 		"Id": "RESCUED_CHERUB_15",
-		"Name": "Elevator exit room cherub",
+		"Name": "Top of elevator Child of Moonlight",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S20"
 	},
 	{
 		"Id": "Lady[D01Z05S22]",
-		"Name": "MD Lady of Sorrows",
+		"Name": "Lady of the Six Sorrows, from MD",
 		"Hint": "The Lady of Sorrows holds *",
 		"Room": "D01Z05S22"
 	},
@@ -548,7 +548,7 @@
 	},
 	{
 		"Id": "Sword[D01Z05S24]",
-		"Name": "Mea Culpa shrine",
+		"Name": "Mea Culpa altar",
 		"Hint": "* requires a golden chalice",
 		"Room": "D01Z05S24"
 	},
@@ -561,14 +561,14 @@
 	},
 	{
 		"Id": "RESCUED_CHERUB_22",
-		"Name": "Elevator shaft cherub",
+		"Name": "Elevator shaft Child of Moonlight",
 		"Hint": "* resides in the Cistern",
 		"Room": "D01Z05S25",
 		"Logic": "linen || (obscureSkipsAllowed && (D01Z05S25[SW] || D01Z05S25[SE] || D01Z05S25[NE]) && (aubade || cantina)) || (pillar && (D01Z05S25[E] || D01Z05S25[W] && (canWalkOnRoot || canCrossGap3)))"
 	},
 	{
 		"Id": "Lady[D01Z05S26]",
-		"Name": "GA Lady of Sorrows",
+		"Name": "Lady of the Six Sorrows, elevator shaft",
 		"Hint": "The Lady of Sorrows holds *",
 		"Room": "D01Z05S26"
 	},
@@ -582,82 +582,82 @@
 	
 	{
 		"Id": "QI101",
-		"Name": "Entrance room",
+		"Name": "Temple entrance",
 		"Hint": "* resides in Petrous",
 		"Room": "D01Z06S01"
 	},
 	
 	{
 		"Id": "CO11",
-		"Name": "WotBC entrance",
+		"Name": "Below Prie Dieu",
 		"Hint": "* resides with the Olive Trees",
 		"Room": "D02Z01S01",
 		"Logic": "D02Z01S01[W] || D02Z01S01[CherubsL] || D02Z01S01[SW] || D02Z01S01[CherubsR] || doubleJump || wallClimb"
 	},
 	{
 		"Id": "QI59",
-		"Name": "Gemino intial gift",
+		"Name": "Gemino's gift",
 		"Hint": "Gemino holds *",
 		"Room": "D02Z01S01",
 		"Logic": "D02Z01S01[W] || D02Z01S01[CherubsL] || wallClimb || doubleJump || ((D02Z01S01[SW] || D02Z01S01[CherubsR]) && canDawnJump)"
 	},
 	{
 		"Id": "RB10",
-		"Name": "Gemino final gift",
+		"Name": "Gemino's reward",
 		"Hint": "Gemino holds *",
 		"Room": "D02Z01S01",
 		"Logic": "fullThimble && (D02Z01S01[W] || D02Z01S01[CherubsL] || wallClimb || doubleJump || ((D02Z01S01[SW] || D02Z01S01[CherubsR]) && canDawnJump))"
 	},
 	{
 		"Id": "RESCUED_CHERUB_23",
-		"Name": "Eastern root cherub",
+		"Name": "Upper east Child of Moonlight",
 		"Hint": "* resides with the Olive Trees",
 		"Room": "D02Z01S02",
 		"Logic": "D02Z01S02[NE] || (D02Z01S02[NW] || wallClimb || doubleJump) && (canWalkOnRoot || canCrossGap4 || pillar)"
 	},
 	{
 		"Id": "QI20",
-		"Name": "Healing cave",
+		"Name": "Entrance to tomb",
 		"Hint": "* resides with the Olive Trees",
 		"Room": "D02Z01S04"
 	},
 	{
 		"Id": "QI68",
-		"Name": "White lady flower",
+		"Name": "Gift for the tomb",
 		"Hint": "Gemino holds *",
 		"Room": "D02Z01S04",
 		"Logic": "fullThimble && (D02Z01S01[W] || D02Z01S01[CherubsL] || wallClimb || doubleJump || ((D02Z01S01[SW] || D02Z01S01[CherubsR]) && canDawnJump))"
 	},
 	{
 		"Id": "QI07",
-		"Name": "Western ghost room",
+		"Name": "Death run",
 		"Hint": "* resides with the Olive Trees",
 		"Room": "D02Z01S05"
 	},
 	{
 		"Id": "CO19",
-		"Name": "Large cave ledge",
+		"Name": "Underground ledge",
 		"Hint": "* resides with the Olive Trees",
 		"Room": "D02Z01S06",
 		"Logic": "wallClimb && (doubleJump || blood && (dash || D02Z01S06[Cherubs]))"
 	},
 	{
 		"Id": "RESCUED_CHERUB_27",
-		"Name": "Large cave cherub",
+		"Name": "Underground Child of Moonlight",
 		"Hint": "* resides with the Olive Trees",
 		"Room": "D02Z01S06",
 		"Logic": "(D02Z01S06[W] || dash || doubleJump && wallClimb) && (pillar || cante || canDiveLaser) || (wallClimb && (D02Z01S06[W] || doubleJump || dash)) && (lorquiana || aubade || cantina || canAirStall)"
 	},
 	{
 		"Id": "PR04",
-		"Name": "White lady tomb",
+		"Name": "Underground tomb",
 		"Hint": "A lady's tomb holds *",
 		"Room": "D02Z01S08",
 		"Logic": "driedFlowers"
 	},
 	{
 		"Id": "HE05",
-		"Name": "Eastern root ledge",
+		"Name": "Upper east statue",
 		"Hint": "* resides with the Olive Trees",
 		"Room": "D02Z01S09",
 		"Logic": "canWalkOnRoot || canCrossGap11 || doubleJump && canEnemyBounce"
@@ -665,49 +665,49 @@
 	
 	{
 		"Id": "RESCUED_CHERUB_24",
-		"Name": "Center shaft cherub",
+		"Name": "Center shaft Child of Moonlight",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S02",
 		"Logic": "D02Z02S02[CherubsL] || D02Z02S02[CherubsR] || ((D02Z02S02[NW] || D02Z02S02[NE] || wallClimb) && (doubleJump || pillar || cante || tirana || canDiveLaser))"
 	},
 	{
 		"Id": "QI46",
-		"Name": "Eastern shaft lower",
+		"Name": "Lower east shaft",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S03",
 		"Logic": "D02Z02S03[NW] || D02Z02S03[NE] || wallClimb || canCrossGap2"
 	},
 	{
 		"Id": "CO29",
-		"Name": "Eastern shaft middle",
+		"Name": "Center east shaft",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S03",
 		"Logic": "D02Z02S03[NW] || D02Z02S03[NE] || wallClimb || doubleJump"
 	},
 	{
 		"Id": "QI08",
-		"Name": "Eastern shaft upper",
+		"Name": "Upper east shaft",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S03",
 		"Logic": "canClimbOnRoot && (D02Z02S03[NE] || doubleJump || blood) || blood && doubleJump"
 	},
 	{
 		"Id": "RB32",
-		"Name": "Western shaft lower",
+		"Name": "Lower west shaft",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S04",
 		"Logic": "D02Z02S04[E]"
 	},
 	{
 		"Id": "CO01",
-		"Name": "Western shaft upper",
+		"Name": "Upper west shaft",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S04",
 		"Logic": "D02Z02S04[NE] || ((D02Z02S04[W] || D02Z02S04[E] && dash) && (doubleJump || wallClimb)) || (D02Z02S04[SE] && (wallClimb || doubleJump && canEnemyUpslash))"
 	},
 	{
 		"Id": "RESCUED_CHERUB_25",
-		"Name": "Western shaft cherub",
+		"Name": "West shaft Child of Moonlight",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S04",
 		"Logic": "(D02Z02S04[NE] || D02Z02S04[W] || D02Z02S04[E] && dash || D02Z02S04[SE] && (wallClimb || doubleJump && canEnemyUpslash)) && (blood && dash || doubleJump && canEnemyBounce || lorquiana || cante || verdiales || aubade || cantina) || (D02Z02S04[NE] || D02Z02S04[W] || D02Z02S04[E] && dash || D02Z02S04[SE]) && pillar"
@@ -721,27 +721,27 @@
 	},
 	{
 		"Id": "RB38",
-		"Name": "Guilt room",
+		"Name": "Confessor Dungeon room",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S06"
 	},
 	{
 		"Id": "CO42",
-		"Name": "Shop cave hole",
+		"Name": "Shop cave hidden hole",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S08",
 		"Logic": "D02Z02S08[CherubsR] || blood || canBreakHoles || canCrossGap8"
 	},
 	{
 		"Id": "RESCUED_CHERUB_31",
-		"Name": "Shop cave cherub",
+		"Name": "Shop cave Child of Moonlight",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S08",
 		"Logic": "D02Z02S08[CherubsR] || canDiveLaser || blood || pillar || canCrossGap8"
 	},
 	{
 		"Id": "Oil[D02Z02S10]",
-		"Name": "Oil room",
+		"Name": "Oil of the Pilgrims",
 		"Hint": "An oil fountain holds *",
 		"Room": "D02Z02S10"
 	},
@@ -753,52 +753,52 @@
 	},
 	{
 		"Id": "RESCUED_CHERUB_26",
-		"Name": "Elevator shaft cherub",
+		"Name": "Elevator shaft Child of Moonlight",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S11"
 	},
 	{
 		"Id": "Lady[D02Z02S12]",
-		"Name": "Lady of Sorrows",
+		"Name": "Lady of the Six Sorrows",
 		"Hint": "The Lady of Sorrows holds *",
 		"Room": "D02Z02S12"
 	},
 	{
 		"Id": "HE11",
-		"Name": "Bleed room",
+		"Name": "Self sacrifice statue",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S13"
 	},
 	{
 		"Id": "RB106",
-		"Name": "Amanecida ledge",
+		"Name": "East cliffside",
 		"Hint": "* resides in the Graveyard",
 		"Room": "D02Z02S14"
 	},
 	{
 		"Id": "Amanecida[D02Z02S14]",
-		"Name": "Defeat Amanecida of the Bejeweled Arrow",
+		"Name": "Amanecida of the Bejeweled Arrow",
 		"Hint": "* is guarded by the Bejeweled Arrow",
 		"Room": "D02Z02S14",
 		"Logic": "canBeatGraveyardBoss"
 	},
 	{
 		"Id": "QI11",
-		"Name": "Shop left",
+		"Name": "Shop item 1",
 		"Hint": "* can be purchased",
 		"LocationFlag": "LOCATION_QI11~D02Z02",
 		"Room": "D02BZ02S01"
 	},
 	{
 		"Id": "RB37",
-		"Name": "Shop middle",
+		"Name": "Shop item 2",
 		"Hint": "* can be purchased",
 		"LocationFlag": "LOCATION_RB37~D02Z02",
 		"Room": "D02BZ02S01"
 	},
 	{
 		"Id": "RB02",
-		"Name": "Shop right",
+		"Name": "Shop item 3",
 		"Hint": "* can be purchased",
 		"LocationFlag": "LOCATION_RB02~D02Z02",
 		"Room": "D02BZ02S01"
@@ -806,46 +806,46 @@
 	
 	{
 		"Id": "CO05",
-		"Name": "Blood platform ledge",
+		"Name": "Snowy window ledge",
 		"Hint": "* resides in the Convent",
 		"Room": "D02Z03S03",
 		"Logic": "D02Z03S03[NW] || blood || canCrossGap3"
 	},
 	{
 		"Id": "RB08",
-		"Name": "Central lung room",
+		"Name": "Center miasma room",
 		"Hint": "* resides in the Convent",
 		"Room": "D02Z03S05",
 		"Logic": "dash && (D02Z03S05[S] || D02Z03S05[NE] || wallClimb || doubleJump)"
 	},
 	{
 		"Id": "CO15",
-		"Name": "Ghost death room",
+		"Name": "Center enemy lineup",
 		"Hint": "* resides in the Convent",
 		"Room": "D02Z03S07"
 	},
 	{
 		"Id": "HE03",
-		"Name": "Southwest lung room",
+		"Name": "Lower west statue",
 		"Hint": "* resides in the Convent",
 		"Room": "D02Z03S12",
 		"Logic": "canSurvivePoison1 && dash"
 	},
 	{
 		"Id": "Sword[D02Z03S13]",
-		"Name": "Mea Culpa shrine",
-		"Hint": "A Mea Culpa Shrine holds *",
+		"Name": "Mea Culpa altar",
+		"Hint": "A Mea Culpa altar holds *",
 		"Room": "D02Z03S13"
 	},
 	{
 		"Id": "Lady[D02Z03S15]",
-		"Name": "Lady of Sorrows",
+		"Name": "Lady of the Six Sorrows",
 		"Hint": "The Lady of Sorrows holds *",
 		"Room": "D02Z03S15"
 	},
 	{
 		"Id": "RB24",
-		"Name": "Blue candle",
+		"Name": "First blue candle",
 		"Hint": "A candle holds *",
 		"Room": "D02Z03S17"
 	},
@@ -857,20 +857,20 @@
 	},
 	{
 		"Id": "BS03",
-		"Name": "Defeat Our Lady of the Charred Visage",
+		"Name": "Our Lady of the Charred Visage",
 		"Hint": "* is guarded by Our Lady of the Charred Visage",
 		"Room": "D02Z03S20",
 		"Logic": "canBeatConventBoss"
 	},
 	{
 		"Id": "QI40",
-		"Name": "Holy Visage gift",
+		"Name": "Visage of Compunction",
 		"Hint": "A Holy Visage holds *",
 		"Room": "D02Z03S21"
 	},
 	{
 		"Id": "QI57",
-		"Name": "Burning oil fountain",
+		"Name": "Fountain of burning oil",
 		"Hint": "The fountain of burning oil holds *",
 		"Type": 9,
 		"OriginalItem": "QI57",
@@ -879,55 +879,55 @@
 	},
 	{
 		"Id": "RB107",
-		"Name": "Outside area",
+		"Name": "Outside pathway",
 		"Hint": "* resides in the Convent",
 		"Room": "D02Z03S23"
 	},
 	
 	{
 		"Id": "CO13",
-		"Name": "DC entrance",
+		"Name": "Under entrance to DC",
 		"Hint": "* resides in the Mountains",
 		"Room": "D03Z01S01"
 	},
 	{
 		"Id": "QI47",
-		"Name": "Bell gap ledge",
+		"Name": "Platform above chasm",
 		"Hint": "* resides in the Mountains",
 		"Room": "D03Z01S03",
 		"Logic": "(blood || doubleJump) && (D03Z01S03[W] || D03Z01S03[SW] || canCrossGap9)"
 	},
 	{
 		"Id": "RB22",
-		"Name": "Redento meeting 1",
+		"Name": "1st meeting with Redento",
 		"Hint": "Redento holds *",
 		"Room": "D03Z01S03",
 		"Logic": "D03Z01S03[W] || D03Z01S03[SW] || canCrossGap9"
 	},
 	{
 		"Id": "RESCUED_CHERUB_16",
-		"Name": "Bell gap cherub",
+		"Name": "Child of Moonlight, above chasm",
 		"Hint": "* resides in the Mountains",
 		"Room": "D03Z01S03",
 		"Logic": "D03Z01S03[W] || D03Z01S03[SW] || canCrossGap9"
 	},
 	{
 		"Id": "Amanecida[D03Z01S03]",
-		"Name": "Defeat Amanecida of the Golden Blades",
+		"Name": "Amanecida of the Golden Blades",
 		"Hint": "* is guarded by the Golden Blades",
 		"Room": "D03Z01S03",
 		"Logic": "canBeatJondoBoss && (D03Z01S03[W] || D03Z01S03[SW] || canCrossGap9)"
 	},
 	{
 		"Id": "QI63",
-		"Name": "Blood platform",
+		"Name": "Blood platform alcove",
 		"Hint": "* resides in the Mountains",
 		"Room": "D03Z01S04",
 		"Logic": "blood || doubleJump || upwarpSkipsAllowed"
 	},
 	{
 		"Id": "RB13",
-		"Name": "Perpetua gift",
+		"Name": "Perpetva",
 		"Hint": "* is guarded by Perpetva",
 		"Room": "D03Z01S06",
 		"Logic": "canBeatPerpetua"
@@ -944,229 +944,229 @@
 	
 	{
 		"Id": "CO08",
-		"Name": "Eastern entrance ledge",
+		"Name": "Upper east ledge",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S01"
 	},
 	{
 		"Id": "PR10",
-		"Name": "Eastern entrance chest",
+		"Name": "Upper east chest",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S01",
 		"Logic": "D03Z02S01[Cherubs] || canClimbOnRoot || canCrossGap8 || doubleJump && canEnemyBounce"
 	},
 	{
 		"Id": "CO33",
-		"Name": "Eastern shaft bell chargers",
+		"Name": "Lower east under chargers",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S04",
 		"Logic": "D03Z02S04[NE] || D03Z02S04[S] || wallClimb"
 	},
 	{
 		"Id": "RESCUED_CHERUB_18",
-		"Name": "Eastern shaft cherub",
+		"Name": "Upper east Child of Moonlight",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S05",
 		"Logic": "D03Z02S05[E] || D03Z02S05[S] || canCrossGap5 || (canEnemyBounce && canCrossGap3)"
 	},
 	{
 		"Id": "QI19",
-		"Name": "Eastern shaft bell trap",
+		"Name": "Lower east bell trap",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S06"
 	},
 	{
 		"Id": "CO07",
-		"Name": "Western shaft lower slide",
+		"Name": "Lower west lift alcove",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S07"
 	},
 	{
 		"Id": "QI41",
-		"Name": "Western shaft bell trap",
+		"Name": "Lower west bell alcove",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S08",
 		"Logic": "D03Z02S08[N] || D03Z02S08[W] || wallClimb || doubleJump"
 	},
 	{
 		"Id": "RESCUED_CHERUB_17",
-		"Name": "Western shaft cherub",
+		"Name": "Upper west Child of Moonlight",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S10"
 	},
 	{
 		"Id": "HE06",
-		"Name": "Spike tunnel ledge",
+		"Name": "Spike tunnel statue",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S11",
 		"Logic": "D03Z02S11[W] && doubleJump || D03Z02S11[E] && dash && (wallClimb || canCrossGap2 || preciseSkipsAllowed && canCrossGap1)"
 	},
 	{
 		"Id": "RESCUED_CHERUB_37",
-		"Name": "Spike tunnel cherub",
+		"Name": "Spike tunnel Child of Moonlight",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S11",
 		"Logic": "D03Z02S11[W] && (doubleJump || dash && (wallClimb || canCrossGap2 && canEnemyBounce || canCrossGap3)) || D03Z02S11[E] && dash && (canCrossGap1 || wallClimb || canEnemyBounce)"
 	},
 	{
 		"Id": "QI52",
-		"Name": "Western shaft bell puzzle",
+		"Name": "Upper west bell puzzle",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S12"
 	},
 	{
 		"Id": "RB28",
-		"Name": "Western shaft root puzzle",
+		"Name": "Upper west tree root",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S13",
 		"Logic": "canWalkOnRoot || canCrossGap3"
 	},
 	{
 		"Id": "QI103",
-		"Name": "EoS entrance",
+		"Name": "Spike tunnel cave",
 		"Hint": "* resides in the Bell",
 		"Room": "D03Z02S15"
 	},
 
 	{
 		"Id": "QI44",
-		"Name": "Western lung ledge",
+		"Name": "Lower west ledge",
 		"Hint": "* resides in the Grievance",
 		"Room": "D03Z03S02",
 		"Logic": "canSurvivePoison1"
 	},
 	{
 		"Id": "CO12",
-		"Name": "Lung room lower",
+		"Name": "Miasma room floor",
 		"Hint": "* resides in the Grievance",
 		"Room": "D03Z03S06",
 		"Logic": "canSurvivePoison1"
 	},
 	{
 		"Id": "RE07",
-		"Name": "Lung room upper",
+		"Name": "Miasma room treasure",
 		"Hint": "* resides in the Grievance",
 		"Room": "D03Z03S06",
 		"Logic": "wallClimb"
 	},
 	{
 		"Id": "RESCUED_CHERUB_19",
-		"Name": "Lung room cherub",
+		"Name": "Miasma room Child of Moonlight",
 		"Hint": "* resides in the Grievance",
 		"Room": "D03Z03S06",
 		"Logic": "wallClimb || canCrossGap11 && taranto && obscureSkipsAllowed"
 	},
 	{
 		"Id": "QI10",
-		"Name": "Blood tunnel ledge",
+		"Name": "End of blood bridge",
 		"Hint": "* resides in the Grievance",
 		"Room": "D03Z03S08",
 		"Logic": "blood || canCrossGap11 || canEnemyBounce && canCrossGap7"
 	},
 	{
 		"Id": "RESCUED_CHERUB_21",
-		"Name": "Blood tunnel cherub",
+		"Name": "Blood bridge Child of Moonlight",
 		"Hint": "* resides in the Grievance",
 		"Room": "D03Z03S08",
 		"Logic": "(blood || canCrossGap11 || canEnemyBounce && canCrossGap7) && (doubleJump || pillar || cante || verdiales || tirana || aubade && canAirStall)"
 	},
 	{
 		"Id": "RESCUED_CHERUB_20",
-		"Name": "Altasgracias cherub",
+		"Name": "Lower east Child of Moonlight",
 		"Hint": "* resides in the Grievance",
 		"Room": "D03Z03S09",
 		"Logic": "canClimbOnRoot || doubleJump || pillar || lorquiana || zarabanda || cante || aubade || tirana"
 	},
 	{
 		"Id": "QI13",
-		"Name": "Altasgracias gift",
+		"Name": "Altasgracias' gift",
 		"Hint": "Altasgracias holds *",
 		"Room": "D03Z03S10",
 		"Logic": "ceremonyItems >= 3"
 	},
 	{
 		"Id": "RB06",
-		"Name": "Altasgracias cacoon",
+		"Name": "Empty giant egg",
 		"Hint": "Altasgracias holds *",
 		"Room": "D03Z03S10",
 		"Logic": "ceremonyItems >= 3 && hatchedEgg && (D01Z02S01[W] || D01Z02S01[E])"
 	},
 	{
 		"Id": "Oil[D03Z03S13]",
-		"Name": "Oil room",
+		"Name": "Oil of the Pilgrims",
 		"Hint": "An oil fountain holds *",
 		"Room": "D03Z03S13"
 	},
 	{
 		"Id": "BS04",
-		"Name": "Defeat Tres Angustias",
+		"Name": "Tres Angustias",
 		"Hint": "* is guarded by Tres Angustias",
 		"Room": "D03Z03S15",
 		"Logic": "canBeatGrievanceBoss"
 	},
 	{
 		"Id": "QI39",
-		"Name": "Holy Visage gift",
+		"Name": "Visage of Contrition",
 		"Hint": "A Holy Visage holds *",
 		"Room": "D03Z03S16"
 	},
 	
 	{
 		"Id": "CO23",
-		"Name": "Garden 1 ledge",
+		"Name": "First area ledge",
 		"Hint": "* resides in the Patio",
 		"Room": "D04Z01S01",
 		"Logic": "D04Z01S01[NE] || D04Z01S01[N] || canCrossGap3"
 	},
 	{
 		"Id": "RESCUED_CHERUB_35",
-		"Name": "Garden 1 cherub",
+		"Name": "First area Child of Moonlight",
 		"Hint": "* resides in the Patio",
 		"Room": "D04Z01S01"
 	},
 	{
 		"Id": "RB14",
-		"Name": "Garden 2 ledge",
+		"Name": "Second area ledge",
 		"Hint": "* resides in the Patio",
 		"Room": "D04Z01S02",
 		"Logic": "canClimbOnRoot || canCrossGap3"
 	},
 	{
 		"Id": "QI37",
-		"Name": "Garden 3 lower ledge",
+		"Name": "Third area lower ledge",
 		"Hint": "* resides in the Patio",
 		"Room": "D04Z01S03"
 	},
 	{
 		"Id": "CO39",
-		"Name": "Garden 3 upper ledge",
+		"Name": "Third area upper ledge",
 		"Hint": "* resides in the Patio",
 		"Room": "D04Z01S03",
 		"Logic": "canClimbOnRoot || canCrossGap3"
 	},
 	{
 		"Id": "RESCUED_CHERUB_28",
-		"Name": "Garden 3 cherub",
+		"Name": "Third area Child of Moonlight",
 		"Hint": "* resides in the Patio",
 		"Room": "D04Z01S03"
 	},
 	{
 		"Id": "RB21",
-		"Name": "Redento meeting 4",
+		"Name": "4th meeting with Redento",
 		"Hint": "Redento holds *",
 		"Room": "D04Z01S04",
 		"Logic": "redentoRooms >= 4"
 	},
 	{
 		"Id": "Amanecida[D04Z01S04]",
-		"Name": "Defeat Amanecida of the Chiselled Steel",
+		"Name": "Amanecida of the Chiselled Steel",
 		"Hint": "* is guarded by the Chiselled Steel",
 		"Room": "D04Z01S04",
 		"Logic": "canBeatPatioBoss"
 	},
 	{
 		"Id": "QI102",
-		"Name": "Northern shaft",
+		"Name": "Climb to WotHP",
 		"Hint": "* resides in the Patio",
 		"Room": "D04Z01S06"
 	},
@@ -1180,58 +1180,58 @@
 	},
 	{
 		"Id": "RESCUED_CHERUB_30",
-		"Name": "Western room cherub",
+		"Name": "Lower west Child of Moonlight",
 		"Hint": "* resides in the Mother",
 		"Room": "D04Z02S01",
 		"Logic": "D04Z02S01[N] || pillar || doubleJump || D04Z02S01[NE] && dash && (wallClimb || canCrossGap1)"
 	},
 	{
 		"Id": "CO17",
-		"Name": "Outside guilt room",
+		"Name": "Upper west floor",
 		"Hint": "* resides in the Mother",
 		"Room": "D04Z02S02"
 	},
 	{
 		"Id": "CO34",
-		"Name": "Outside Cleofas room",
+		"Name": "Outside Cleofas' room",
 		"Hint": "* resides in the Mother",
 		"Room": "D04Z02S06",
 		"Logic": "D04Z02S06[NW] || D04Z02S06[N] || D04Z02S06[NE] || wallClimb || doubleJump"
 	},
 	{
 		"Id": "CO35",
-		"Name": "Eastern room lower",
+		"Name": "East Chandelier platform",
 		"Hint": "* resides in the Mother",
 		"Room": "D04Z02S07",
 		"Logic": "dash && (blood || canCrossGap3)"
 	},
 	{
 		"Id": "RB33",
-		"Name": "Eastern room upper",
+		"Name": "Upper east ledge",
 		"Hint": "* resides in the Mother",
 		"Room": "D04Z02S07"
 	},
 	{
 		"Id": "CO20",
-		"Name": "Center room ledge",
+		"Name": "Upper center floor",
 		"Hint": "* resides in the Mother",
 		"Room": "D04Z02S11"
 	},
 	{
 		"Id": "RESCUED_CHERUB_29",
-		"Name": "Center room cherub",
+		"Name": "Upper center Child of Moonlight",
 		"Hint": "* resides in the Mother",
 		"Room": "D04Z02S11"
 	},
 	{
 		"Id": "Sword[D04Z02S12]",
-		"Name": "Mea Culpa shrine",
-		"Hint": "A Mea Culpa Shrine holds *",
+		"Name": "Mea Culpa altar",
+		"Hint": "A Mea Culpa altar holds *",
 		"Room": "D04Z02S12"
 	},
 	{
 		"Id": "Oil[D04Z02S14]",
-		"Name": "Oil room",
+		"Name": "Oil of the Pilgrims",
 		"Hint": "An oil fountain holds *",
 		"Room": "D04Z02S14"
 	},
@@ -1243,28 +1243,28 @@
 	},
 	{
 		"Id": "HE01",
-		"Name": "Blood incense shaft",
+		"Name": "Giant chandelier statue",
 		"Hint": "* resides in the Mother",
 		"Room": "D04Z02S16",
 		"Logic": "wallClimb && (blood || doubleJump)"
 	},
 	{
 		"Id": "BS05",
-		"Name": "Defeat Melquiades",
+		"Name": "Melquiades, The Exhumed Archbishop",
 		"Hint": "* is guarded by Melquiades",
 		"Room": "D04Z02S22",
 		"Logic": "canBeatMothersBoss"
 	},
 	{
 		"Id": "RE03",
-		"Name": "Redento prayer room",
+		"Name": "Redento's treasure",
 		"Hint": "* is locked away in a room",
 		"LocationFlag": "LOCATION_RE03~D04Z02",
 		"Room": "D04BZ02S01"
 	},
 	{
 		"Id": "QI54",
-		"Name": "Redento corpse",
+		"Name": "Final meeting with Redento",
 		"Hint": "Redento holds *",
 		"LocationFlag": "LOCATION_QI54~D04Z02",
 		"Room": "D04BZ02S01",
@@ -1273,7 +1273,7 @@
 	
 	{
 		"Id": "HE201",
-		"Name": "Fourth Visage gift",
+		"Name": "Gift from the Traitor",
 		"Hint": "The Fourth Visage holds *",
 		"Room": "D04Z03S02",
 		"Logic": "traitorEyes >= 2"
@@ -1281,7 +1281,7 @@
 	
 	{
 		"Id": "PR201",
-		"Name": "Miriam gift",
+		"Name": "Miriam's gift",
 		"Hint": "Miriam holds *",
 		"Type": 8,
 		"Room": "D04Z04S01",
@@ -1296,7 +1296,7 @@
 	},
 	{
 		"Id": "RESCUED_CHERUB_01",
-		"Name": "Platform room cherub",
+		"Name": "Platform room Child of Moonlight",
 		"Hint": "* resides in the Library",
 		"Room": "D05Z01S04"
 	},
@@ -1309,14 +1309,14 @@
 	},
 	{
 		"Id": "CO22",
-		"Name": "Upper cathedral ledge",
+		"Name": "Root ceiling platform",
 		"Hint": "* resides in the Library",
 		"Room": "D05Z01S05",
 		"Logic": "(canClimbOnRoot || doubleJump) && (D05Z01S05[NE] || blood)"
 	},
 	{
 		"Id": "RB31",
-		"Name": "Lung ambush chest",
+		"Name": "Miasma hallway chest",
 		"Hint": "* resides in the Library",
 		"Room": "D05Z01S06",
 		"Logic": "D05Z01S06[W] || canSurvivePoison3"
@@ -1330,39 +1330,39 @@
 	},
 	{
 		"Id": "RB203",
-		"Name": "Diosdado gift",
+		"Name": "Silence for Diosdado",
 		"Hint": "Diosdado holds *",
 		"Room": "D05Z01S11",
 		"Logic": "(D05Z01S11[NW] || D05Z01S11[NE]) && D05Z01S23[E]"
 	},
 	{
 		"Id": "CO28",
-		"Name": "Diosdado ledge",
+		"Name": "Lowest west upper ledge",
 		"Hint": "* resides in the Library",
 		"Room": "D05Z01S11",
 		"Logic": "D05Z01S11[NW] || D05Z01S11[NE]"
 	},
 	{
 		"Id": "RB30",
-		"Name": "Final shaft ledge",
+		"Name": "Lowest west center ledge",
 		"Hint": "* resides in the Library",
 		"Room": "D05Z01S11"
 	},
 	{
 		"Id": "RESCUED_CHERUB_02",
-		"Name": "Final shaft cherub",
+		"Name": "Lowest west Child of Moonlight",
 		"Hint": "* resides in the Library",
 		"Room": "D05Z01S11"
 	},
 	{
 		"Id": "Sword[D05Z01S13]",
-		"Name": "Mea Culpa shrine",
-		"Hint": "A Mea Culpa Shrine holds *",
+		"Name": "Mea Culpa altar",
+		"Hint": "A Mea Culpa altar holds *",
 		"Room": "D05Z01S13"
 	},
 	{
 		"Id": "Lady[D05Z01S14]",
-		"Name": "Lady of Sorrows",
+		"Name": "Lady of the Six Sorrows",
 		"Hint": "The Lady of Sorrows holds *",
 		"Room": "D05Z01S14"
 	},
@@ -1380,20 +1380,20 @@
 	},
 	{
 		"Id": "Oil[D05Z01S19]",
-		"Name": "Oil room",
+		"Name": "Oil of the Pilgrims",
 		"Hint": "An oil fountain holds *",
 		"Room": "D05Z01S19"
 	},
 	{
 		"Id": "RESCUED_CHERUB_32",
-		"Name": "Elevator cherub",
+		"Name": "Elevator Child of Moonlight",
 		"Hint": "* resides in the Library",
 		"Room": "D05Z01S21",
 		"Logic": "blood && (canWalkOnRoot || doubleJump || canCrossGap5 && pillar) || obscureSkipsAllowed && (zarabanda || aubade || cantina)"
 	},
 	{
 		"Id": "RB301",
-		"Name": "Fourth Visage hidden wall",
+		"Name": "Twisted wood hidden wall",
 		"Hint": "* is locked away in a room",
 		"LocationFlag": "LOCATION_RB301~D05Z01",
 		"Room": "D05BZ01S01"
@@ -1401,26 +1401,26 @@
 	
 	{
 		"Id": "QI64",
-		"Name": "Herb shaft",
+		"Name": "Painting ladder ledge",
 		"Hint": "* resides in the Canvases",
 		"Room": "D05Z02S02"
 	},
 	{
 		"Id": "HE07",
-		"Name": "Wax bleed puzzle",
+		"Name": "Candle wax puzzle",
 		"Hint": "* requires large beads of wax",
 		"Room": "D05Z02S08"
 	},
 	{
 		"Id": "RE05",
-		"Name": "Jocinero first gift",
+		"Name": "Jocinero's 1st reward",
 		"Hint": "Jocinero holds *",
 		"Room": "D05Z02S10",
 		"Logic": "cherubs >= 20"
 	},
 	{
 		"Id": "PR05",
-		"Name": "Jocinero second gift",
+		"Name": "Jocinero's final reward",
 		"Hint": "Jocinero holds *",
 		"Type": 8,
 		"Room": "D05Z02S10",
@@ -1428,41 +1428,41 @@
 	},
 	{
 		"Id": "CO31",
-		"Name": "Linen drop room",
+		"Name": "Under elevator shaft",
 		"Hint": "* resides in the Canvases",
 		"Room": "D05Z02S11"
 	},
 	{
 		"Id": "BS06",
-		"Name": "Defeat Exposito",
+		"Name": "Exposito, Scion of Abjuration",
 		"Hint": "* is guarded by Exposito",
 		"Room": "D05Z02S14",
 		"Logic": "canBeatCanvasesBoss"
 	},
 	{
 		"Id": "QI104",
-		"Name": "Low tunnel blade trap",
+		"Name": "Swinging blade tunnel",
 		"Hint": "* resides in the Canvases",
 		"Room": "D05Z02S15",
 		"Logic": "dash"
 	},
 	{
 		"Id": "RB12",
-		"Name": "Shop left",
+		"Name": "Shop item 1",
 		"Hint": "* can be purchased",
 		"LocationFlag": "LOCATION_RB12~D05Z02",
 		"Room": "D05BZ02S01"
 	},
 	{
 		"Id": "QI49",
-		"Name": "Shop middle",
+		"Name": "Shop item 2",
 		"Hint": "* can be purchased",
 		"LocationFlag": "LOCATION_QI49~D05Z02",
 		"Room": "D05BZ02S01"
 	},
 	{
 		"Id": "QI71",
-		"Name": "Shop right",
+		"Name": "Shop item 3",
 		"Hint": "* can be purchased",
 		"LocationFlag": "LOCATION_QI71~D05Z02",
 		"Room": "D05BZ02S01"
@@ -1470,74 +1470,74 @@
 	
 	{
 		"Id": "QI02",
-		"Name": "Bridge fight 1",
+		"Name": "First soldier fight",
 		"Hint": "* is guarded by a Legionary",
 		"Room": "D06Z01S03",
 		"Logic": "canBeatLegionary"
 	},
 	{
 		"Id": "QI03",
-		"Name": "Bridge fight 2",
+		"Name": "Second soldier fight",
 		"Hint": "* is guarded by a Legionary",
 		"Room": "D06Z01S06",
 		"Logic": "canBeatLegionary && (D06Z01S06[WW] || D06Z01S06[E])"
 	},
 	{
 		"Id": "QI04",
-		"Name": "Bridge fight 3",
+		"Name": "Third soldier fight",
 		"Hint": "* is guarded by a Legionary",
 		"Room": "D06Z01S21",
 		"Logic": "canBeatLegionary"
 	},
 	{
 		"Id": "Sword[D06Z01S11]",
-		"Name": "Mea Culpa shrine",
-		"Hint": "A Mea Culpa Shrine holds *",
+		"Name": "Mea Culpa altar",
+		"Hint": "A Mea Culpa altar holds *",
 		"Room": "D06Z01S11"
 	},
 	{
 		"Id": "CO06",
-		"Name": "Western shaft ledge",
+		"Name": "Upper west shaft ledge",
 		"Hint": "* resides in the Rooftops",
 		"Room": "D06Z01S12",
 		"Logic": "D06Z01S12[NW] || D06Z01S12[NE] || D06Z01S12[NE2] || D06Z01S12[W] || D06Z01S12[E] || wallClimb"
 	},
 	{
 		"Id": "PR12",
-		"Name": "Western shaft chest",
+		"Name": "Upper west shaft chest",
 		"Hint": "* resides in the Rooftops",
 		"Room": "D06Z01S12",
 		"Logic": "D06Z01S12[NE2] || (D06Z01S12[NW] || D06Z01S12[NE]) && doubleJump"
 	},
 	{
 		"Id": "RESCUED_CHERUB_36",
-		"Name": "Western shaft cherub",
+		"Name": "Upper west shaft Child of Moonlight",
 		"Hint": "* resides in the Rooftops",
 		"Room": "D06Z01S12",
 		"Logic": "D06Z01S12[W] || D06Z01S12[E] || D06Z01S12[NW] || D06Z01S12[NE] || D06Z01S12[NE2] || wallClimb && (doubleJump || taranto)"
 	},
 	{
 		"Id": "CO40",
-		"Name": "Upper eastern shaft ledge",
+		"Name": "Upper east shaft ledge",
 		"Hint": "* resides in the Rooftops",
 		"Room": "D06Z01S15",
 		"Logic": "D06Z01S15[SW] && (wallClimb && (canCrossGap10 || canClimbOnRoot && (blood || preciseSkipsAllowed && (doubleJump || canAirStall) || doubleJump && canAirStall)) || doubleJump && canEnemyBounce)"
 	},
 	{
 		"Id": "HE04",
-		"Name": "MoM eastern entrance",
+		"Name": "Statue near MoM",
 		"Hint": "* resides in the Rooftops",
 		"Room": "D06Z01S22"
 	},
 	{
 		"Id": "Lady[D06Z01S24]",
-		"Name": "Lady of Sorrows",
+		"Name": "Lady of the Six Sorrows",
 		"Hint": "The Lady of Sorrows holds *",
 		"Room": "D06Z01S24"
 	},
 	{
 		"Id": "BS16",
-		"Name": "Defeat Crisanta",
+		"Name": "Crisanta of the Wrapped Agony",
 		"Hint": "* is guarded by Crisanta",
 		"Room": "D06Z01S25",
 		"Logic": "canBeatRooftopsBoss"
@@ -1545,28 +1545,28 @@
 	
 	{
 		"Id": "PR08",
-		"Name": "Viridiana gift",
+		"Name": "Viridiana's gift",
 		"Hint": "Viridiana holds *",
 		"Room": "D07Z01S01"
 	},
 
 	{
 		"Id": "BS12",
-		"Name": "Defeat Esdras",
+		"Name": "Esdras, of the Anointed Legion",
 		"Hint": "* is guarded by Esdras",
 		"Room": "D08Z01S01",
 		"Logic": "holyWounds >= 3 && canBeatBridgeBoss"
 	},
 	{
 		"Id": "PR09",
-		"Name": "Esdras bridge gift",
+		"Name": "Esdras' gift",
 		"Hint": "* is guarded by Esdras",
 		"Room": "D08Z01S01",
 		"Logic": "holyWounds >= 3 && canBeatBridgeBoss"
 	},
 	{
 		"Id": "HE101",
-		"Name": "Inside Amanecida statue",
+		"Name": "Inside giant statue",
 		"Hint": "* resides on the Bridge",
 		"Room": "D08Z01S02"
 	},
@@ -1579,7 +1579,7 @@
 	},
 	{
 		"Id": "LaudesBossTrigger[30000]",
-		"Name": "Defeat Laudes",
+		"Name": "Laudes, the First of the Amanecidas",
 		"Hint": "* is guarded by Laudes",
 		"Room": "D08Z03S03",
 		"Logic": "canBeatHallBoss"
@@ -1587,75 +1587,75 @@
 	
 	{
 		"Id": "Amanecida[D09Z01S01]",
-		"Name": "Defeat Amanecida of the Molten Thorn",
+		"Name": "Amanecida of the Molten Thorn",
 		"Hint": "* is guarded by the Molten Thorn",
 		"Room": "D09Z01S01",
 		"Logic": "canBeatWallBoss"
 	},
 	{
 		"Id": "QI51",
-		"Name": "Q1 middle gold door",
+		"Name": "Upper east room, center gold cell",
 		"Hint": "* is locked away in a room",
 		"Room": "D09Z01S02",
 		"Logic": "D09Z01S02[Cell5]"
 	},
 	{
 		"Id": "RB11",
-		"Name": "Q1 lift puzzle",
+		"Name": "Upper east room, lift puzzle",
 		"Hint": "* resides in the Wall",
 		"Room": "D09Z01S02",
 		"Logic": "D09Z01S02[NW] || D09Z01S02[N] || D09Z01S02[Cell1] || D09Z01S02[Cell6] || D09Z01S02[Cell4] || D09Z01S02[Cell3] || D09Z01S02[Cell22] || D09Z01S02[Cell23]"
 	},
 	{
 		"Id": "BS14",
-		"Name": "Defeat Quirce",
+		"Name": "Quirce, Returned By The Flames",
 		"Hint": "* is guarded by Quirce",
 		"Room": "D09Z01S03",
 		"Logic": "canBeatPrisonBoss"
 	},
 	{
 		"Id": "RESCUED_CHERUB_05",
-		"Name": "Elevator cherub",
+		"Name": "Outside Child of Moonlight",
 		"Hint": "* resides in the Wall",
 		"Room": "D09Z01S06"
 	},
 	{
 		"Id": "QI72",
-		"Name": "Quirce room",
+		"Name": "Collapsing floor ledge",
 		"Hint": "* resides in the Wall",
 		"Room": "D09Z01S08",
 		"Logic": "(D09Z01S08[W] || D09Z01S08[Cell18]) && openedWotHPGate"
 	},
 	{
 		"Id": "RB16",
-		"Name": "Q3 upper ledge",
+		"Name": "Lower west room, top ledge",
 		"Hint": "* resides in the Wall",
 		"Room": "D09Z01S09",
 		"Logic": "D09Z01S09[Cell24] || dash && (D09Z01S09[NW] || D09Z01S09[Cell19] || doubleJump && (canAirStall || canDawnJump))"
 	},
 	{
 		"Id": "QI70",
-		"Name": "Q4 upper bronze door",
+		"Name": "Lower east room, top bronze cell",
 		"Hint": "* is locked away in a room",
 		"Room": "D09Z01S10",
 		"Logic": "D09Z01S10[Cell13]"
 	},
 	{
 		"Id": "CO27",
-		"Name": "Q4 hidden ledge",
+		"Name": "Lower east room, hidden ledge",
 		"Hint": "* resides in the Wall",
 		"Room": "D09Z01S10",
 		"Logic": "D09Z01S10[W] || D09Z01S10[Cell12] || D09Z01S10[Cell10] || D09Z01S10[Cell11]"
 	},
 	{
 		"Id": "Oil[D09Z01S12]",
-		"Name": "Oil room",
+		"Name": "Oil of the Pilgrims",
 		"Hint": "An oil fountain holds *",
 		"Room": "D09Z01S12"
 	},
 	{
 		"Id": "CO10",
-		"Name": "Q1 drop room upper",
+		"Name": "Upper east room, center cell ledge",
 		"Hint": "* resides in the Wall",
 		"LocationFlag": "LOCATION_CO10~D09Z01",
 		"Room": "D09BZ01S01",
@@ -1663,7 +1663,7 @@
 	},
 	{
 		"Id": "QI69",
-		"Name": "Q1 drop room lower",
+		"Name": "Upper east room, center cell floor",
 		"Hint": "* resides in the Wall",
 		"LocationFlag": "LOCATION_QI69~D09Z01",
 		"Room": "D09BZ01S01",
@@ -1671,7 +1671,7 @@
 	},
 	{
 		"Id": "RESCUED_CHERUB_03",
-		"Name": "Q1 upper bronze door",
+		"Name": "Upper east room, top bronze cell",
 		"Hint": "* resides in the Wall",
 		"LocationFlag": "LOCATION_RESCUED_CHERUB_03~D09Z01",
 		"Room": "D09BZ01S01",
@@ -1679,7 +1679,7 @@
 	},
 	{
 		"Id": "CO24",
-		"Name": "Q1 upper silver door",
+		"Name": "Upper east room, top silver cell",
 		"Hint": "* is locked away in a room",
 		"LocationFlag": "LOCATION_CO24~D09Z01",
 		"Room": "D09BZ01S01",
@@ -1687,7 +1687,7 @@
 	},
 	{
 		"Id": "RESCUED_CHERUB_34",
-		"Name": "Q2 upper silver door",
+		"Name": "Upper west room, top silver cell",
 		"Hint": "* resides in the Wall",
 		"LocationFlag": "LOCATION_RESCUED_CHERUB_34~D09Z01",
 		"Room": "D09BZ01S01",
@@ -1695,7 +1695,7 @@
 	},
 	{
 		"Id": "CO26",
-		"Name": "Q2 middle gold door",
+		"Name": "Upper west room, center gold cell",
 		"Hint": "* is locked away in a room",
 		"LocationFlag": "LOCATION_CO26~D09Z01",
 		"Room": "D09BZ01S01",
@@ -1703,7 +1703,7 @@
 	},
 	{
 		"Id": "CO02",
-		"Name": "Q3 lower gold door",
+		"Name": "Lower west room, bottom gold cell",
 		"Hint": "* is locked away in a room",
 		"LocationFlag": "LOCATION_CO02~D09Z01",
 		"Room": "D09BZ01S01",
@@ -1711,7 +1711,7 @@
 	},
 	{
 		"Id": "CO37",
-		"Name": "Q4 upper silver door",
+		"Name": "Lower east room, top silver cell",
 		"Hint": "* is locked away in a room",
 		"LocationFlag": "LOCATION_CO37~D09Z01",
 		"Room": "D09BZ01S01",
@@ -1719,7 +1719,7 @@
 	},
 	{
 		"Id": "RESCUED_CHERUB_04",
-		"Name": "Q4 lower silver door",
+		"Name": "Lower east room, bottom silver cell",
 		"Hint": "* resides in the Wall",
 		"LocationFlag": "LOCATION_RESCUED_CHERUB_04~D09Z01",
 		"Room": "D09BZ01S01",
@@ -1728,55 +1728,55 @@
 	
 	{
 		"Id": "RB204",
-		"Name": "Initial room ledge",
+		"Name": "Starting room ledge",
 		"Hint": "* resides in the Brotherhood",
 		"Room": "D17Z01S01",
 		"Logic": "D17Z01S01[Cherubs3]"
 	},
 	{
 		"Id": "RESCUED_CHERUB_06",
-		"Name": "Initial room cherub",
+		"Name": "Starting room Child of Moonlight",
 		"Hint": "* resides in the Brotherhood",
 		"Room": "D17Z01S01",
 		"logic": "D17Z01S01[Cherubs1] || taranto || (canClimbOnRoot || canCrossGap9) && (blood || doubleJump || debla || verdiales || tirana || ruby)"
 	},
 	{
 		"Id": "RE401",
-		"Name": "Redento meeting 2",
+		"Name": "2nd meeting with Redento",
 		"Hint": "Redento holds *",
 		"Room": "D17Z01S04",
 		"Logic": "redentoRooms >= 2"
 	},
 	{
 		"Id": "Sword[D17Z01S08]",
-		"Name": "Mea Culpa shrine",
-		"Hint": "A Mea Culpa Shrine holds *",
+		"Name": "Mea Culpa altar",
+		"Hint": "A Mea Culpa altar holds *",
 		"Room": "D17Z01S08"
 	},
 	{
 		"Id": "BS13",
-		"Name": "Defeat Warden of the Silent Sorrow",
+		"Name": "Warden of the Silent Sorrow",
 		"Hint": "* is guarded by the Warden",
 		"Room": "D17Z01S11",
 		"Logic": "canBeatBrotherhoodBoss"
 	},
 	{
 		"Id": "PR203",
-		"Name": "Church entrance",
+		"Name": "Outside church",
 		"Hint": "* resides in the Brotherhood",
 		"Room": "D17Z01S14",
 		"Logic": "D17Z01S14[W] || blood"
 	},
 	{
 		"Id": "QI204",
-		"Name": "Esdras church gift",
+		"Name": "Esdras' final gift",
 		"Hint": "Esdras holds *",
 		"Room": "D17Z01S15",
 		"Logic": "canBeatBridgeBoss && holyWounds >= 3"
 	},
 	{
 		"Id": "QI301",
-		"Name": "Crisanta church gift",
+		"Name": "Crisanta's gift",
 		"Hint": "Crisanta holds *",
 		"Type": 9,
 		"OriginalItem": "QI301",
@@ -1792,7 +1792,7 @@
 	},
 	{
 		"Id": "CO25",
-		"Name": "Spike gaunlet exit",
+		"Name": "Platforming gauntlet",
 		"Hint": "* resides in the Brotherhood",
 		"LocationFlag": "LOCATION_CO25~D17Z01",
 		"Room": "D17BZ02S01",
@@ -1801,13 +1801,13 @@
 	
 	{
 		"Id": "RB108",
-		"Name": "MotED entrance",
+		"Name": "Lantern jump near MotED",
 		"Hint": "* resides in the salts",
 		"Room": "D20Z01S02"
 	},
 	{
 		"Id": "RB202",
-		"Name": "Near elevator shaft",
+		"Name": "Lantern jump near elevator",
 		"Hint": "* resides in the salts",
 		"Room": "D20Z01S09",
 		"Logic": "D20Z01S09[W] || dash"
@@ -1815,47 +1815,47 @@
 	
 	{
 		"Id": "RB201",
-		"Name": "Eastern chest",
+		"Name": "Upper east chest",
 		"Hint": "* resides in Mourning",
 		"Room": "D20Z02S02"
 	},
 	{
 		"Id": "BossTrigger[5000]",
-		"Name": "Defeat Sierpes",
+		"Name": "Sierpes",
 		"Hint": "* is guarded by Sierpes",
 		"Room": "D20Z02S08",
 		"Logic": "canBeatMourningBoss"
 	},
 	{
 		"Id": "QI202",
-		"Name": "Sierpes reward",
+		"Name": "Sierpes' eye",
 		"Hint": "* is guarded by Sierpes",
 		"Room": "D20Z02S08",
 		"Logic": "canBeatMourningBoss"
 	},
 	{
 		"Id": "PR202",
-		"Name": "Western chest",
+		"Name": "West chest",
 		"Hint": "* resides in Mourning",
 		"Room": "D20Z02S11"
 	},
 	
 	{
 		"Id": "QI203",
-		"Name": "Perpetua shrine",
+		"Name": "Perpetva's shrine",
 		"Hint": "Perpetva holds *",
 		"Room": "D20Z03S01"
 	},
 	
 	{
 		"Id": "QI106",
-		"Name": "Starting item",
+		"Name": "Beginning gift",
 		"Hint": "* is already owned",
 		"Room": "Initial"
 	},
 	{
 		"Id": "RB18",
-		"Name": "Red candle 1",
+		"Name": "Second red candle",
 		"Hint": "A candle holds *",
 		"LocationFlag": "CANDLE_RED_1_USED~D02Z03",
 		"Room": "Initial",
@@ -1863,7 +1863,7 @@
 	},
 	{
 		"Id": "RB19",
-		"Name": "Red candle 2",
+		"Name": "Third red candle",
 		"Hint": "A candle holds *",
 		"LocationFlag": "CANDLE_RED_2_USED~D05Z01",
 		"Room": "Initial",
@@ -1871,7 +1871,7 @@
 	},
 	{
 		"Id": "RB25",
-		"Name": "Blue candle 1",
+		"Name": "Second blue candle",
 		"Hint": "A candle holds *",
 		"LocationFlag": "CANDLE_BLUE_1_USED~D17Z01",
 		"Room": "Initial",
@@ -1879,7 +1879,7 @@
 	},
 	{
 		"Id": "RB26",
-		"Name": "Blue candle 2",
+		"Name": "Third blue candle",
 		"Hint": "A candle holds *",
 		"LocationFlag": "CANDLE_BLUE_2_USED~D01Z04",
 		"Room": "Initial",
@@ -1926,7 +1926,7 @@
 	},
 	{
 		"Id": "QI32",
-		"Name": "Guilt arena 1 main",
+		"Name": "Confessor Dungeon 1 main",
 		"Hint": "A guilt statue holds *",
 		"Type": 2,
 		"OriginalItem": "TH",
@@ -1936,7 +1936,7 @@
 	},
 	{
 		"Id": "QI33",
-		"Name": "Guilt arena 2 main",
+		"Name": "Confessor Dungeon 2 main",
 		"Hint": "A guilt statue holds *",
 		"Type": 2,
 		"OriginalItem": "TH",
@@ -1946,7 +1946,7 @@
 	},
 	{
 		"Id": "QI34",
-		"Name": "Guilt arena 3 main",
+		"Name": "Confessor Dungeon 3 main",
 		"Hint": "A guilt statue holds *",
 		"Type": 2,
 		"OriginalItem": "TH",
@@ -1956,7 +1956,7 @@
 	},
 	{
 		"Id": "QI35",
-		"Name": "Guilt arena 4 main",
+		"Name": "Confessor Dungeon 4 main",
 		"Hint": "A guilt statue holds *",
 		"Type": 2,
 		"OriginalItem": "TH",
@@ -1966,7 +1966,7 @@
 	},
 	{
 		"Id": "QI79",
-		"Name": "Guilt arena 5 main",
+		"Name": "Confessor Dungeon 5 main",
 		"Hint": "A guilt statue holds *",
 		"Type": 2,
 		"OriginalItem": "TH",
@@ -1976,7 +1976,7 @@
 	},
 	{
 		"Id": "QI80",
-		"Name": "Guilt arena 6 main",
+		"Name": "Confessor Dungeon 6 main",
 		"Hint": "A guilt statue holds *",
 		"Type": 2,
 		"OriginalItem": "TH",
@@ -1986,7 +1986,7 @@
 	},
 	{
 		"Id": "QI81",
-		"Name": "Guilt arena 7 main",
+		"Name": "Confessor Dungeon 7 main",
 		"Hint": "A guilt statue holds *",
 		"Type": 2,
 		"OriginalItem": "TH",
@@ -1996,7 +1996,7 @@
 	},
 	{
 		"Id": "Arena_NailManager[1000]",
-		"Name": "Guilt arena 1 extra",
+		"Name": "Confessor Dungeon 1 extra",
 		"Hint": "A guilt statue holds *",
 		"LocationFlag": "CONFESSOR_1_ARENACOMPLETED~D01Z04",
 		"Room": "Initial",
@@ -2004,7 +2004,7 @@
 	},
 	{
 		"Id": "HE10",
-		"Name": "Guilt arena 2 extra",
+		"Name": "Confessor Dungeon 2 extra",
 		"Hint": "A guilt statue holds *",
 		"LocationFlag": "CONFESSOR_2_ARENACOMPLETED~D02Z02",
 		"Room": "Initial",
@@ -2012,7 +2012,7 @@
 	},
 	{
 		"Id": "Arena_NailManager[3000]",
-		"Name": "Guilt arena 3 extra",
+		"Name": "Confessor Dungeon 3 extra",
 		"Hint": "A guilt statue holds *",
 		"LocationFlag": "CONFESSOR_3_ARENACOMPLETED~D03Z03",
 		"Room": "Initial",
@@ -2020,7 +2020,7 @@
 	},
 	{
 		"Id": "RB34",
-		"Name": "Guilt arena 4 extra",
+		"Name": "Confessor Dungeon 4 extra",
 		"Hint": "A guilt statue holds *",
 		"LocationFlag": "CONFESSOR_4_ARENACOMPLETED~D17Z01",
 		"Room": "Initial",
@@ -2028,7 +2028,7 @@
 	},
 	{
 		"Id": "Arena_NailManager[5000]",
-		"Name": "Guilt arena 5 extra",
+		"Name": "Confessor Dungeon 5 extra",
 		"Hint": "A guilt statue holds *",
 		"LocationFlag": "CONFESSOR_5_ARENACOMPLETED~D04Z02",
 		"Room": "Initial",
@@ -2036,7 +2036,7 @@
 	},
 	{
 		"Id": "RB35",
-		"Name": "Guilt arena 6 extra",
+		"Name": "Confessor Dungeon 6 extra",
 		"Hint": "A guilt statue holds *",
 		"LocationFlag": "CONFESSOR_6_ARENACOMPLETED~D05Z01",
 		"Room": "Initial",
@@ -2044,7 +2044,7 @@
 	},
 	{
 		"Id": "RB36",
-		"Name": "Guilt arena 7 extra",
+		"Name": "Confessor Dungeon 7 extra",
 		"Hint": "A guilt statue holds *",
 		"LocationFlag": "CONFESSOR_7_ARENACOMPLETED~D09Z01",
 		"Room": "Initial",
@@ -2052,7 +2052,7 @@
 	},
 	{
 		"Id": "COMBO_1",
-		"Name": "First skill tier 1",
+		"Name": "Skill 1, Tier 1",
 		"Hint": "A tier 1 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "COMBO",
@@ -2061,7 +2061,7 @@
 	},
 	{
 		"Id": "COMBO_2",
-		"Name": "First skill tier 2",
+		"Name": "Skill 1, Tier 2",
 		"Hint": "A tier 2 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "COMBO",
@@ -2070,7 +2070,7 @@
 	},
 	{
 		"Id": "COMBO_3",
-		"Name": "First skill tier 3",
+		"Name": "Skill 1, Tier 3",
 		"Hint": "A tier 4 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "COMBO",
@@ -2079,7 +2079,7 @@
 	},
 	{
 		"Id": "CHARGED_1",
-		"Name": "Second skill tier 1",
+		"Name": "Skill 2, Tier 1",
 		"Hint": "A tier 1 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "CHARGED",
@@ -2088,7 +2088,7 @@
 	},
 	{
 		"Id": "CHARGED_2",
-		"Name": "Second skill tier 2",
+		"Name": "Skill 2, Tier 2",
 		"Hint": "A tier 3 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "CHARGED",
@@ -2097,7 +2097,7 @@
 	},
 	{
 		"Id": "CHARGED_3",
-		"Name": "Second skill tier 3",
+		"Name": "Skill 2, Tier 3",
 		"Hint": "A tier 6 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "CHARGED",
@@ -2106,7 +2106,7 @@
 	},
 	{
 		"Id": "RANGED_1",
-		"Name": "Third skill tier 1",
+		"Name": "Skill 3, Tier 1",
 		"Hint": "A tier 2 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "RANGED",
@@ -2115,7 +2115,7 @@
 	},
 	{
 		"Id": "RANGED_2",
-		"Name": "Third skill tier 2",
+		"Name": "Skill 3, Tier 2",
 		"Hint": "A tier 5 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "RANGED",
@@ -2124,7 +2124,7 @@
 	},
 	{
 		"Id": "RANGED_3",
-		"Name": "Third skill tier 3",
+		"Name": "Skill 3, Tier 3",
 		"Hint": "A tier 7 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "RANGED",
@@ -2133,7 +2133,7 @@
 	},
 	{
 		"Id": "VERTICAL_1",
-		"Name": "Fifth skill tier 1",
+		"Name": "Skill 4, Tier 1",
 		"Hint": "A tier 1 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "DIVE",
@@ -2142,7 +2142,7 @@
 	},
 	{
 		"Id": "VERTICAL_2",
-		"Name": "Fifth skill tier 2",
+		"Name": "Skill 4, Tier 2",
 		"Hint": "A tier 3 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "DIVE",
@@ -2151,7 +2151,7 @@
 	},
 	{
 		"Id": "VERTICAL_3",
-		"Name": "Fifth skill tier 3",
+		"Name": "Skill 4, Tier 3",
 		"Hint": "A tier 6 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "DIVE",
@@ -2160,7 +2160,7 @@
 	},
 	{
 		"Id": "LUNGE_1",
-		"Name": "Fourth skill tier 1",
+		"Name": "Skill 5, Tier 1",
 		"Hint": "A tier 1 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "LUNGE",
@@ -2169,7 +2169,7 @@
 	},
 	{
 		"Id": "LUNGE_2",
-		"Name": "Fourth skill tier 2",
+		"Name": "Skill 5, Tier 2",
 		"Hint": "A tier 2 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "LUNGE",
@@ -2178,11 +2178,11 @@
 	},
 	{
 		"Id": "LUNGE_3",
-		"Name": "Fourth skill tier 3",
+		"Name": "Skill 5, Tier 3",
 		"Hint": "A tier 4 shrine holds *",
 		"Type": 1,
 		"OriginalItem": "LUNGE",
 		"Room": "Initial",
 		"Logic": "swordRooms >= 4 && tears >= 0"
-	},
+	}
 ]


### PR DESCRIPTION
Self explanatory. Updates the location names to match the names used in [multiworld.](https://github.com/ArchipelagoMW/Archipelago/blob/main/worlds/blasphemous/Locations.py)